### PR TITLE
Update schism.py

### DIFF
--- a/roms2schism/schism.py
+++ b/roms2schism/schism.py
@@ -338,7 +338,7 @@ class schism_grid(object):
         opbd = tmp.copy()       
         self.b_xi, self.b_yi = x[opbd], y[opbd]  # only at the bry nodes
         self.b_bbox = bbox(hgrid.x[opbd], hgrid.y[opbd], offset = bbox_offset)
-        self.NOP = len(opbn)       # number of open boundary nodes
+        self.NOP = len(opbd)       # number of open boundary nodes
         self.nvrt = zcor.shape[1]
         self.b_lon = hgrid.x[opbd]  # OB lons
         self.b_lat = hgrid.y[opbd]  # OB lats


### PR DESCRIPTION
There is what seems to be a typo on line 341 of schism.py

Also, the README suggest installing the package with `pip install roms2schism`. 
But that will install an older version of roms2schism. I suggest recommending the installation using:
`pip install git+https://github.com/ivicajan/ROMS2SCHISM.git`